### PR TITLE
Feat/local charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ helm-diagrams https://charts.jetstack.io/cert-manager
 
 # generate a diagram for the Helm chart 'argo-cd' available in OCI repository 'ghcr.io'
 helm-diagrams oci://ghcr.io/argoproj/argo-helm/argo-cd
+
+# generate a diagram for the Helm chart 'some-chart' available locally
+helm-diagrams some-path/some-chart
 ```
 
 ### With Docker/Podman

--- a/bin/helm-diagrams
+++ b/bin/helm-diagrams
@@ -19,7 +19,8 @@ if [[ ${repository} == oci* ]]
 then
   # Deal with OCI registries.
   helm template ${chart} $1 2> /dev/null | kube-diagrams $KD_OPTS --without-namespace -o $chart -
-else
+elif [[ ${repository} == http* ]]
+then
   # Deal with HTTP registries.
 
   # Add a Helm repository.
@@ -31,4 +32,7 @@ else
 
   # Remove the Helm repository.
   helm repo remove $rid >/dev/null
+else
+  # Deal with local charts
+  helm template ${repository}/${chart} 2> /dev/null | kube-diagrams $KD_OPTS --without-namespace -o local-$chart -
 fi


### PR DESCRIPTION
adding the ability to render local charts

i want to use the tool locally without pushing any charts

or to be used in CI to generate diagrams as part of the release process 

prepending local- onto the output name only because when the chart is in the current directory, you get an error within the diagram call. could probably be enhanced but was going for a quick win here. 