### PR TITLE
chore: update flake for packaging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,7 @@
+# Contributing
+
 All contributions are welcome, just submit pull requests, and we will review and integrate them as soon as possible.
+
+## Development Environment
+
+If you have [`nix`](https://nixos.org/download) installed on your machine, you can enter into the development environment via `nix develop`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1743576891,
@@ -18,7 +36,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,21 +3,53 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs }: {
-    devShells.aarch64-darwin.default = let
-      pkgs = nixpkgs.legacyPackages.aarch64-darwin;
-    in
-      pkgs.mkShell {
-        packages = with pkgs; [
-          git
-          lazygit
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        pythonEnv = pkgs.python312.withPackages (ps: [ ps.pyyaml ps.diagrams ]);
 
+        kube-diagrams = pkgs.stdenv.mkDerivation rec {
+          pname = "kube-diagrams";
+          version = "0.2.0";
+          src = self;
+          postPatch = ''
+            substituteInPlace bin/kube-diagrams \
+              --replace '/usr/bin/env python3' '${pythonEnv}/bin/python'
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp -r bin/* $out/bin/
+            chmod +x $out/bin/*-diagrams
+          '';
+        };
+
+        runtimeEnv = with pkgs; [
+          busybox
+          cacert
           graphviz
-          nodePackages.prettier
-          python39
+          kubernetes-helm
+          kube-diagrams
+          pythonEnv
         ];
-      };
-  };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            git
+            lazygit
+            nodePackages.prettier
+          ] ++ runtimeEnv;
+        };
+
+        packages.default = pkgs.dockerTools.buildLayeredImage {
+          name = "ghcr.io/philippemerle/kubediagrams";
+          tag = "latest";
+          contents = runtimeEnv;
+          created = "now";
+        };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -44,11 +44,15 @@
           ] ++ runtimeEnv;
         };
 
-        packages.default = pkgs.dockerTools.buildLayeredImage {
-          name = "ghcr.io/philippemerle/kubediagrams";
-          tag = "latest";
-          contents = runtimeEnv;
-          created = "now";
+        packages = {
+          default = kube-diagrams;
+          kube-diagrams = kube-diagrams;
+          docker = pkgs.dockerTools.buildLayeredImage {
+            name = "ghcr.io/philippemerle/kubediagrams";
+            tag = "latest";
+            contents = runtimeEnv;
+            created = "now";
+          };
         };
       }
     );


### PR DESCRIPTION
Now, you can also build a slightly more efficient Docker image via Nix: `nix build .#docker`. Our developer shell (accessible via `nix develop`) will now also come with `helm` and our other dependencies.

This guarantees that the same software in development is what is packaged in the Docker image built with Nix. (I added instructions about this in the `CONTRIBUTING.md` file.)