### PR TITLE
build : Add multiarch (arm) to docker image build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,4 +39,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          tags: adamab/kubediagrams:latest
+          tags: philippemerle/kubediagrams:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,17 +18,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
         name: Build and push
         uses: docker/build-push-action@v6
         with:
-          push: true
-          tags: philippemerle/kubediagrams:latest
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: adamab/kubediagrams:latest

--- a/bin/kube-diagrams.yaml
+++ b/bin/kube-diagrams.yaml
@@ -1,4 +1,4 @@
-# Configuration of kube-diagrams # TODO REVERT CHANGE &
+# Configuration of kube-diagrams
 default_namespace: default
 edges:
   REFERENCE:

--- a/bin/kube-diagrams.yaml
+++ b/bin/kube-diagrams.yaml
@@ -1,4 +1,4 @@
-# Configuration of kube-diagrams
+# Configuration of kube-diagrams # TODO REVERT CHANGE
 default_namespace: default
 edges:
   REFERENCE:

--- a/bin/kube-diagrams.yaml
+++ b/bin/kube-diagrams.yaml
@@ -1,4 +1,4 @@
-# Configuration of kube-diagrams # TODO REVERT CHANGE
+# Configuration of kube-diagrams # TODO REVERT CHANGE &
 default_namespace: default
 edges:
   REFERENCE:


### PR DESCRIPTION
Was trying the docker image on an M1 mac and got hit with the (no manifest available for this platform).

So I tried to add that 😄 .

- Built and tested the image [here](https://hub.docker.com/repository/docker/adamab/kubediagrams/tags/latest/sha256-33dfcc8828a51c23b15c93ce9eee64ffffaa6670ab1583e40dd2852c30a64e31)