### PR TITLE
Correctly install graphviz2drawio in Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,23 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        
+        graphviz2drawio = let
+          pname = "graphviz2drawio";
+          version = "1.1.0";
+        in
+          pkgs.python3Packages.buildPythonPackage {
+            inherit pname version;
+            src = pkgs.fetchPypi {
+              inherit pname version;
+              sha256 = "sha256-h1i57vusXYwDoDWMAViEUjXJw8qpmIfw9gJs/swolfI=";
+            };
+          };
+
         pythonEnv = pkgs.python312.withPackages (ps: [
           ps.pyyaml
           ps.diagrams
+          graphviz2drawio
         ]);
 
         kube-diagrams = pkgs.stdenv.mkDerivation {

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
 
         kube-diagrams = pkgs.stdenv.mkDerivation {
           pname = "kube-diagrams";
-          version = "0.3.0";
+          version = "0.7.0";
           src = self;
           postPatch = ''
             substituteInPlace bin/kube-diagrams \


### PR DESCRIPTION
Pulls the latest `graphviz2drawio` from PyPi and installs via Nix flake.

Fixes #69 