### PR TITLE
feat(webapp): add Monaco editor and improve UI components

### DIFF
--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -12,8 +12,10 @@
     "format:check": "prettier --check \"src/**/*.{js,jsx,json,css}\""
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@tailwindcss/vite": "^4.1.18",
     "lucide-react": "^0.574.0",
+    "monaco-yaml": "^5.5.1",
     "motion": "^12.34.1",
     "prop-types": "^15.8.1",
     "react": "^19.2.4",

--- a/webapp/frontend/src/components/common/CommandDetails.jsx
+++ b/webapp/frontend/src/components/common/CommandDetails.jsx
@@ -6,10 +6,10 @@
 
 import AnsiText from './AnsiText.jsx';
 
-function CommandDetails({ command, stdout, stderr, message }) {
+function CommandDetails({ command, stdout, stderr, message, titleClassName = 'text-gray-800' }) {
   return (
     <div className="mt-6" id="command-details">
-      <h3 className="text-xl font-bold text-gray-800 mb-2">Command Execution Details</h3>
+      <h3 className={`text-xl font-bold ${titleClassName} mb-2`}>Command Execution Details</h3>
       <div className="bg-black text-white p-4 rounded-md text-sm space-y-4 overflow-x-auto">
         {command && (
           <div>

--- a/webapp/frontend/src/components/common/YamlEditor.jsx
+++ b/webapp/frontend/src/components/common/YamlEditor.jsx
@@ -1,0 +1,46 @@
+import Editor from '@monaco-editor/react';
+import { configureMonacoYaml } from 'monaco-yaml';
+
+let configured = false;
+
+function setupMonacoYaml(monaco) {
+  if (configured) return;
+  configured = true;
+  configureMonacoYaml(monaco, {
+    enableSchemaRequest: true,
+    schemas: [
+      {
+        uri: 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0-standalone-strict/all.json',
+        fileMatch: ['*manifest*'],
+      },
+    ],
+  });
+}
+
+function YamlEditor({ value, onChange, path = 'file.yaml' }) {
+  return (
+    <div className="rounded-lg overflow-hidden border border-gray-600" style={{ height: '256px' }}>
+      <Editor
+        height="256px"
+        defaultLanguage="yaml"
+        path={path}
+        value={value}
+        onChange={(val) => onChange(val ?? '')}
+        beforeMount={setupMonacoYaml}
+        theme="vs-dark"
+        options={{
+          minimap: { enabled: true },
+          fontSize: 14,
+          lineNumbers: 'on',
+          wordWrap: 'on',
+          scrollBeyondLastLine: false,
+          automaticLayout: true,
+          tabSize: 2,
+          padding: { top: 8, bottom: 8 },
+        }}
+      />
+    </div>
+  );
+}
+
+export default YamlEditor;

--- a/webapp/frontend/src/components/tabs/ClusterTab/index.jsx
+++ b/webapp/frontend/src/components/tabs/ClusterTab/index.jsx
@@ -215,7 +215,7 @@ function ClusterTab({ historyContext }) {
 
       {/* Command Details Section - Full width below */}
       {(command || stdout || stderr || message) && (
-        <CommandDetails command={command} stdout={stdout} stderr={stderr} message={message} />
+        <CommandDetails command={command} stdout={stdout} stderr={stderr} message={message} titleClassName="text-white" />
       )}
     </div>
   );

--- a/webapp/frontend/src/components/tabs/HelmFileTab/HelmFileInput.jsx
+++ b/webapp/frontend/src/components/tabs/HelmFileTab/HelmFileInput.jsx
@@ -7,6 +7,7 @@ import { Info, Upload } from 'lucide-react';
 import SubmitButton from '../../common/SubmitButton.jsx';
 import ManifestOptions from '../../options/ManifestOptions';
 import ExampleSelector from '../../common/ExampleSelector.jsx';
+import YamlEditor from '../../common/YamlEditor.jsx';
 import { EXAMPLE_TYPES } from '../../../utils/constants.js';
 
 function HelmFileInput({
@@ -30,12 +31,11 @@ function HelmFileInput({
 
       <ExampleSelector type={EXAMPLE_TYPES.HELMFILE} onSelectExample={setHelmfileContent} />
 
-      <textarea
-        className="w-full h-64 p-4 rounded-lg resize-none bg-gray-700 text-white"
-        placeholder="Paste your helmfile.yaml content here..."
+      <YamlEditor
+        path="helmfile.yaml"
         value={helmfileContent}
-        onChange={(e) => {
-          setHelmfileContent(e.target.value);
+        onChange={(val) => {
+          setHelmfileContent(val);
           if (errorMessage) setErrorMessage('');
         }}
       />

--- a/webapp/frontend/src/components/tabs/ManifestTab/ManifestInput.jsx
+++ b/webapp/frontend/src/components/tabs/ManifestTab/ManifestInput.jsx
@@ -7,6 +7,7 @@ import { Info, Upload } from 'lucide-react';
 import SubmitButton from '../../common/SubmitButton.jsx';
 import ManifestOptions from '../../options/ManifestOptions';
 import ExampleSelector from '../../common/ExampleSelector.jsx';
+import YamlEditor from '../../common/YamlEditor.jsx';
 import { EXAMPLE_TYPES } from '../../../utils/constants.js';
 
 function ManifestInput({
@@ -30,12 +31,11 @@ function ManifestInput({
 
       <ExampleSelector type={EXAMPLE_TYPES.MANIFEST} onSelectExample={setManifestContent} />
 
-      <textarea
-        className="w-full h-64 p-4 rounded-lg resize-none bg-gray-700 text-white"
-        placeholder="Paste your Kubernetes manifest YAML here..."
+      <YamlEditor
+        path="manifest.yaml"
         value={manifestContent}
-        onChange={(e) => {
-          setManifestContent(e.target.value);
+        onChange={(val) => {
+          setManifestContent(val);
           if (errorMessage) setErrorMessage('');
         }}
       />

--- a/webapp/frontend/src/hooks/useClusterData.js
+++ b/webapp/frontend/src/hooks/useClusterData.js
@@ -195,9 +195,9 @@ export function useClusterData({
   const commonVisible = filteredResourceTypes.filter(
     (rt) => rt.isCommon && (!isNamespaceContext || rt.namespaced)
   );
-  const otherVisible = filteredResourceTypes.filter(
-    (rt) => !rt.isCommon || (isNamespaceContext && !rt.namespaced)
-  );
+  const otherVisible = filteredResourceTypes
+    .filter((rt) => !rt.isCommon || (isNamespaceContext && !rt.namespaced))
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   return {
     // Data


### PR DESCRIPTION
Changes :

- Add `@monaco-editor/react` and `monaco-yaml` dependencies (`package.json`)                                                                                                                                             
  - Add new `YamlEditor.jsx` component with Monaco editor configured for YAML                                                                                                                                              
    - Syntax highlighting                                                                                                                                                                                                  
    - YAML schema validation                                                                                                                                                                                               
  - Replace plain textarea with `YamlEditor` in `ManifestInput` and `HelmFileInput`                                                                                                                                        
                                                                                                                                                                                                                           
  ### Bug fix — Cluster tab                                                                                                                                                                                                
  - Fix `Others` resource list not being sorted alphabetically (`useClusterData.js`)                                                                                                                                       
  - Fix minor display issues in `ClusterTab` and `CommandDetails`  